### PR TITLE
Add org-wide contributing instructions.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# How to contribute
+
+We'd love to accept your feedback and suggestions on the explainer and specification in
+this repository. Please file any issues you notice. If you want to suggest a change
+to the text, that may indicate that the explainer is ready to move to a standards body's incubation venue, and you can file an issue suggesting that. If it's not ready, you'll need to agree to the Google CLA as described below, or wait until the repository does move to an incubation venue.
+
+## Before you begin
+
+### Sign our Contributor License Agreement
+
+Contributions to this project must be accompanied by a
+[Contributor License Agreement](https://cla.developers.google.com/about) (CLA).
+You (or your employer) retain the copyright to your contribution; this simply
+gives us permission to use and redistribute your contributions as part of the
+project.
+
+If you or your current employer have already signed the Google CLA (even if it
+was for a different project), you probably don't need to do it again.
+
+Visit <https://cla.developers.google.com/> to see your current agreements or to
+sign a new one.
+
+### Review our community guidelines
+
+This project follows
+[Google's Open Source Community Guidelines](https://opensource.google/conduct/)
+and operates under [Chromium's code of conduct](https://chromium.googlesource.com/chromium/src/+/main/CODE_OF_CONDUCT.md).
+
+## Contribution process
+
+### Code reviews
+
+All submissions, including submissions by project members, require review. We
+use GitHub pull requests for this purpose. Consult
+[GitHub Help](https://help.github.com/articles/about-pull-requests/) for more
+information on using pull requests.


### PR DESCRIPTION
See https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file.

@dpranke, I think you were most interested in the content of this file. @cwilso and @reillyeon FYI.